### PR TITLE
Use job.type instead of job.name

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -21,7 +21,7 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local newStress
-    if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.name == 'police') then return end
+    if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.type == 'leo') then return end
     if not ResetStress then
         if not Player.PlayerData.metadata['stress'] then
             Player.PlayerData.metadata['stress'] = 0


### PR DESCRIPTION
Will be useful for people using multiple police jobs. also judging by the seatbelt portion it appears aimed at qbx users who already utilize types in the qbx_policejob.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
